### PR TITLE
If-condition corrected

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -843,7 +843,20 @@ class Mailbox {
 		if(!is_array($args)) {
 			$args = [$args];
 		}
-		if(!in_array($methodShortName, ['open'])) { // duct tape https://github.com/barbushin/php-imap/issues/242
+		 // https://github.com/barbushin/php-imap/issues/242
+		if(in_array($methodShortName, ['open'])) {
+			// Mailbox names that contain international characters besides those in the printable ASCII space have to be encoded with imap_utf7_encode().
+			// https://www.php.net/manual/en/function.imap-open.php
+			if(is_string($args[0])) {
+				if(preg_match("/^\{.*\}(.*)$/", $args[0], $matches)) {
+					$mailbox_name = $matches[1];
+
+					if(!mb_detect_encoding($mailbox_name, 'ASCII', true)) {
+						$args[0] = imap_utf7_encode($mailbox_name);
+					}
+				}
+			}
+		} else {
 			foreach($args as &$arg) {
 				if(is_string($arg)) {
 					$arg = imap_utf7_encode($arg);

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -843,7 +843,7 @@ class Mailbox {
 		if(!is_array($args)) {
 			$args = [$args];
 		}
-		if(in_array($methodShortName, ['open', 'reopen', 'search'])) { // duct tape https://github.com/barbushin/php-imap/issues/242
+		if(!in_array($methodShortName, ['open'])) { // duct tape https://github.com/barbushin/php-imap/issues/242
 			foreach($args as &$arg) {
 				if(is_string($arg)) {
 					$arg = imap_utf7_encode($arg);


### PR DESCRIPTION
The `if`-condition did convert all `$args` using `imap_utf7_encode`, when the called method was `open`, `reopen` or `search`. I've changed it, that all `$args` will be encoded now as long as the called method is NOT `open`.

`reopen` is using the already opened stream, so we do not pass any password to this method and due to this, it is not necessary to disable the utf7 encoding for this method. Same for `search`.
References: [imap_reopen()](https://www.php.net/manual/de/function.imap-reopen.php), [imap_search()](https://www.php.net/manual/de/function.imap-search.php)

Related PR: https://github.com/barbushin/php-imap/pull/281